### PR TITLE
Added vertexIds to GetGraph.graphql

### DIFF
--- a/kgbase/graphql/query/GetGraph.graphql
+++ b/kgbase/graphql/query/GetGraph.graphql
@@ -14,11 +14,16 @@ fragment Edge on EdgeType {
   toId
 }
 
-query GetGraph($context: GraphContextType!, $query: GraphQueryType!, $limits: GraphQueryLimitsType) {
+query GetGraph(
+  $context: GraphContextType!
+  $query: GraphQueryType!
+  $limits: GraphQueryLimitsType
+) {
   getGraph(context: $context, query: $query, limits: $limits) {
     vertices {
       ...Vertex
     }
+    vertexIds
     edges {
       ...Edge
     }


### PR DESCRIPTION
@raphaelseo Would you please look over this change, and then release a pip package?

I just added `vertexIds` to that query.

When you make a `GetGraph` query, it only returns `vertices`. But these vertices would include targets of all the relationships. (So that we could render a table with results of this one request.)

The `vertexId` contains an array with IDs of vertices of the actual query. (So not the connected targets.)

I'm currently using this for Vaccination bar chart.